### PR TITLE
Fixes if user set initialize_on_precompile to false, will fail to compile

### DIFF
--- a/lib/mails_viewer/engine.rb
+++ b/lib/mails_viewer/engine.rb
@@ -8,7 +8,7 @@ module MailsViewer
 
     # Enabling assets precompiling under rails 3.1
     if Rails.version >= '3.1' && Rails.env != 'production'
-      initializer :assets do |app|
+      initializer "MailsViewer precompile hook", :group => :all do |app|
         app.config.assets.precompile += %w(mails_viewer.js mails_viewer.css)
       end
     end


### PR DESCRIPTION
if set `config.assets.initialize_on_precompile = false`, it will fail to compile js and css files.

Same issue with sferik/rails_admin#1192, and this is copied from rails_admin's solution.
