### PR TITLE
Fix: Error raised when to/cc/from are string's and not arrays [issue#7]

### DIFF
--- a/app/views/mails_viewer/home/index.html.erb
+++ b/app/views/mails_viewer/home/index.html.erb
@@ -24,9 +24,9 @@
         <tbody>
           <% @mails.each do |mail, filename| %>
             <tr class="mail">
-              <td><%= mail.from.join(', ') %></td>
-              <td><%= mail.to.join(', ') %></td>
-              <td><%= mail.cc.try(:join, ', ')%></td>
+              <td><%= Array.wrap(mail.from).join(', ') %></td>
+              <td><%= Array.wrap(mail.to).join(', ') %></td>
+              <td><%= Array.wrap(mail.cc).join(', ') %></td>
               <td>
                 <%= mail.subject %>
               </td>


### PR DESCRIPTION
Ensure mail.{from,to,cc} are converted to an `Array` using `Array.wrap` in view.
